### PR TITLE
Match openldap version

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
-[tool.bumpversion]
-current_version = "1.0.0+260520"
+[tool.bumpversion] # Remember to change the OPENLDAP_VERSION_TAG in CI jobs as well
+current_version = "2.5.14+260812"
 parse = "(?P<major>\\d+)\\.(?P<minor>\\d+)\\.(?P<patch>\\d+)\\+(?P<build>\\d+)"
 serialize = ["{major}.{minor}.{patch}+{build}"]
 search = "{current_version}"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,6 +2,7 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Remember to change OPENLDAP_VERSION_TAG also in push_to_main.yml and .bumpversion.toml
 env:
   OPENLDAP_VERSION_TAG: 2.5.14
 
@@ -34,10 +35,11 @@ jobs:
         with:
           product: openldap
           component: server
+          build-args: |
+            OPENLDAP_VERSION_TAG=${{ env.OPENLDAP_VERSION_TAG }}
           dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           acr-repo: ${{ vars.ACR_REPO }}
           acr-username: ${{ vars.ACR_USERNAME }}
           acr-token: ${{ secrets.ACR_TOKEN }}
-          extra-tag: "OPENLDAP-${{ env.OPENLDAP_VERSION_TAG }}"

--- a/.github/workflows/push_to_main.yml
+++ b/.github/workflows/push_to_main.yml
@@ -3,6 +3,8 @@ on:
     branches:
       - main
   workflow_dispatch:
+
+# Remember to change OPENLDAP_VERSION_TAG also in pull_request.yml and .bumpversion.toml
 env:
   OPENLDAP_VERSION_TAG: 2.5.14
 
@@ -20,6 +22,8 @@ jobs:
         with:
           product: openldap
           component: server
+          build-args: |
+            OPENLDAP_VERSION_TAG=${{ env.OPENLDAP_VERSION_TAG }}
           dockerhub-username: ${{ vars.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -15,3 +15,15 @@ Execute inside openldap container with uid of created user:
 ```
 ldapsearch -LL -Y EXTERNAL -H ldapi:/// "(uid=testuser)" -b dc=example,dc=org memberOf
 ```
+
+## Versioning
+
+Versioning is handled with
+[bump-my-version](https://github.com/callowayproject/bump-my-version). To increment, use
+`bump-my-version bump build`.
+
+- Major, minor and patch are the OpenLDAP version
+- Build is change date for _this repo_
+
+When bumping the OpenLDAP version, remember to update `OPENLDAP_VERSION_TAG` in the `Dockerfile`
+and in workflows.


### PR DESCRIPTION
## User-Facing Summary
  - major, minor, patch to be the openldap version
  - build to be the last change date in this repo
  
## Why It's Good for the Product (Release Goal)
- Versioning is more clear

Closes #8 